### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/engine/views.py
+++ b/engine/views.py
@@ -64,7 +64,7 @@ def article(request, slug):
 				sendMail(comment , comment.anser_on_id , request)
 			adminMail(comment ,request)
 			form.save()
-			return redirect('/article/%s' % slug)
+			return redirect('/article/{0!s}'.format(slug))
 		else: 
 			context['comment_form'] = form
 	else:
@@ -114,7 +114,7 @@ def i_like_it(request, slug):
 			nn = LikeAriticle(ip=ip, article=article)
 			nn.save()
 			article.save()
-	return redirect('/article/%s' % slug )
+	return redirect('/article/{0!s}'.format(slug) )
  
 
 
@@ -125,7 +125,7 @@ def sendMail(comment, to_answer, reques):
 	msg.send()
 
 def adminMail(comment,reques):
-	answer = "<h1> Вас приведствует сайт Mr.Byte blog </h1></br><h3>Время "+str(comment.time)+"</h3><h4>Недавно вам оставил комментарий, " + str(comment.name)  + "</h5></br>"+str(comment.comment)+'<div>Для ответа прейдите по ссылке <a href="%s">Ответить</a></div>' % reques.get_full_path()
+	answer = "<h1> Вас приведствует сайт Mr.Byte blog </h1></br><h3>Время "+str(comment.time)+"</h3><h4>Недавно вам оставил комментарий, " + str(comment.name)  + "</h5></br>"+str(comment.comment)+'<div>Для ответа прейдите по ссылке <a href="{0!s}">Ответить</a></div>'.format(reques.get_full_path())
 	msg = EmailMessage('У вас новый комментарий от пользователя '+comment.name,answer,settings.EMAIL_HOST_USER,['simplex.bro@gmail.com'] )
 	msg.content_subtype = "html"
 	msg.send()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mr8bit:blog?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mr8bit:blog?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)